### PR TITLE
Fix: disable tokenizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,10 @@ RUN curl -o instantclient-basic-193000.zip https://download.oracle.com/otn_softw
     && ldconfig
 
 # install php extension
-RUN docker-php-ext-install zip pdo_mysql mysqli tokenizer bcmath opcache pcntl \
+RUN docker-php-ext-install zip pdo_mysql mysqli \
+    # installed by default since PHP 8.1, enable this if PHP 7.3, PHP 7.4
+    # tokenizer 
+    bcmath opcache pcntl \
     && docker-php-ext-configure oci8 --with-oci8=instantclient,/usr/lib/oracle/instantclient_19_3 \
     && docker-php-ext-install -j$(nproc) oci8 
 


### PR DESCRIPTION
Because it was installed by default since PHP 8.1